### PR TITLE
Update to support Raspberry Pi 4

### DIFF
--- a/TFTPTest.lpr
+++ b/TFTPTest.lpr
@@ -3,7 +3,18 @@ program TFTPTest;
 {$mode objfpc}{$H+}
 
 uses
+  {$IFDEF RPI}
+  RaspberryPi,
+  {$ENDIF}
+  {$IFDEF RPI2}
+  RaspberryPi2,
+  {$ENDIF}
+  {$IFDEF RPI3}
   RaspberryPi3,
+  {$ENDIF}
+  {$IFDEF RPI4}
+  RaspberryPi4,
+  {$ENDIF}
   GlobalConfig,
   GlobalConst,
   GlobalTypes,

--- a/uTFTP.pas
+++ b/uTFTP.pas
@@ -456,7 +456,7 @@ begin
                       aTransfer.FStream.Seek (0, soFromBeginning);
                       aFile.CopyFrom (aTransfer.FStream, aTransfer.FStream.Size);
                       aFile.Free;
-                      if (aTransfer.FileName = 'kernel7.img') or (aTransfer.FileName = 'kernel.img') then
+                      if LowerCase(aTransfer.FileName) = LowerCase(ParamStr(0)) then // ParamStr(0) will always be the kernel name
                         begin
                           DoMsg ('Restarting.');
                           SystemRestart (0);


### PR DESCRIPTION
Update the detection of kernel filename so restarting after a kernel upload works on Pi 4